### PR TITLE
Redesign word definitions

### DIFF
--- a/include/plorth/parser/ast.hpp
+++ b/include/plorth/parser/ast.hpp
@@ -260,16 +260,13 @@ namespace plorth::parser::ast
   {
   public:
     using symbol_type = std::shared_ptr<class symbol>;
-    using quote_type = std::shared_ptr<class quote>;
 
     explicit word(
       const struct position& position,
-      const symbol_type& symbol,
-      const quote_type& quote
+      const symbol_type& symbol
     )
       : token(position)
-      , m_symbol(symbol)
-      , m_quote(quote) {}
+      , m_symbol(symbol) {}
 
     inline enum type type() const
     {
@@ -284,18 +281,8 @@ namespace plorth::parser::ast
       return m_symbol;
     }
 
-    /**
-     * Returns contents of the word.
-     */
-    inline const quote_type& quote() const
-    {
-      return m_quote;
-    }
-
   private:
     /** Identifier of the word. */
     const symbol_type m_symbol;
-    /** Contents of the word. */
-    const quote_type m_quote;
   };
 }

--- a/include/plorth/parser/utils.hpp
+++ b/include/plorth/parser/utils.hpp
@@ -131,7 +131,7 @@ namespace plorth::parser::utils
   static inline bool isword(char32_t c)
   {
     return c != '(' && c != ')' && c != '[' && c != ']' && c != '{'
-      && c != '}' && c != ':' && c != ';' && c != ','
+      && c != '}' && c != ','
       && peelo::unicode::ctype::isgraph(c);
   }
 }

--- a/test/test_token.cpp
+++ b/test/test_token.cpp
@@ -64,7 +64,7 @@ static void test_string_with_apostrophe()
 
 static void test_word()
 {
-  const auto result = parse(U": foo bar ;");
+  const auto result = parse(U"-> foo");
 
   assert(!!result);
   assert((*result.value())->type() == token::type::word);

--- a/test/test_utils.cpp
+++ b/test/test_utils.cpp
@@ -81,14 +81,14 @@ static void test_isword()
   assert(!isword(U']'));
   assert(!isword(U'{'));
   assert(!isword(U'}'));
-  assert(!isword(U':'));
-  assert(!isword(U';'));
   assert(!isword(U','));
   assert(!isword(U' '));
 
   assert(isword(U'a'));
   assert(isword(U'-'));
   assert(isword(U'\u00e4'));
+  assert(isword(U':'));
+  assert(isword(U';'));
 }
 
 int main(int argc, char** argv)

--- a/test/test_visitor.cpp
+++ b/test/test_visitor.cpp
@@ -111,9 +111,7 @@ static void test_visit_word()
 {
   test_visitor visitor;
   auto symbol = std::make_shared<class symbol>(position, U"");
-  const quote::container_type children = {};
-  auto quote = std::make_shared<class quote>(position, children);
-  auto token = std::make_shared<word>(position, symbol, quote);
+  auto token = std::make_shared<word>(position, symbol);
   bool flag = false;
 
   visitor.visit(token, flag);


### PR DESCRIPTION
Switch from Forth style word definitions into ones used by Laskin, so that word definitions are now an arrow symbol `->` followed by an identifier.